### PR TITLE
Update Travis Linux build to use swiftenv install script from GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       env: SWIFT_VERSION=5.0.1
       os: linux
       language: generic
-      install: eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+      install: eval "$(curl -sL https://raw.githubusercontent.com/kylef/swiftenv/1.4.0/docs/install.sh)"
       script: swift test --parallel
 
     - <<: *linux


### PR DESCRIPTION
https://swiftenv.fuller.li/install.sh went down and broke the Linux builds on Travis.

This updates Travis to use the swiftenv install script directly from GitHub.